### PR TITLE
DuplicateTimes

### DIFF
--- a/2017ClubChampionshipEvent1.htm
+++ b/2017ClubChampionshipEvent1.htm
@@ -597,3 +597,4 @@ font-style:normal'>Club Championship 2017 Event 1</h1>
 
 
 
+

--- a/2017ClubChampionshipEvent10.htm
+++ b/2017ClubChampionshipEvent10.htm
@@ -225,3 +225,4 @@ font-style:normal'>Club Championship 2017 Event 10</h1>
 
 
 
+

--- a/2017ClubChampionshipEvent11.htm
+++ b/2017ClubChampionshipEvent11.htm
@@ -278,3 +278,4 @@ font-style:normal'>Club Championship 2017 Event 11</h1>
 
 
 
+

--- a/2017ClubChampionshipEvent2.htm
+++ b/2017ClubChampionshipEvent2.htm
@@ -500,3 +500,4 @@ font-style:normal'>Club Championship 2017 Event 2</h1>
 
 
 
+

--- a/2017ClubChampionshipEvent3.htm
+++ b/2017ClubChampionshipEvent3.htm
@@ -524,3 +524,4 @@ font-style:normal'>Club Championship 2017 Event 3</h1>
 
 
 
+

--- a/2017ClubChampionshipEvent4.htm
+++ b/2017ClubChampionshipEvent4.htm
@@ -536,3 +536,4 @@ font-style:normal'>Club Championship 2017 Event 4</h1>
 
 
 
+

--- a/2017ClubChampionshipEvent5.htm
+++ b/2017ClubChampionshipEvent5.htm
@@ -618,3 +618,4 @@ font-style:normal'>Club Championship 2017 Event 5</h1>
 
 
 
+

--- a/2017ClubChampionshipEvent6.htm
+++ b/2017ClubChampionshipEvent6.htm
@@ -488,3 +488,4 @@ font-style:normal'>Club Championship 2017 Event 6</h1>
 
 
 
+

--- a/2017ClubChampionshipEvent7.htm
+++ b/2017ClubChampionshipEvent7.htm
@@ -270,3 +270,4 @@ font-style:normal'>Club Championship 2017 Event 7</h1>
 
 
 
+

--- a/2017ClubChampionshipEvent8.htm
+++ b/2017ClubChampionshipEvent8.htm
@@ -269,3 +269,4 @@ font-style:normal'>Club Championship 2017 Event 8</h1>
 
 
 
+

--- a/2017ClubChampionshipEvent9.htm
+++ b/2017ClubChampionshipEvent9.htm
@@ -269,3 +269,4 @@ font-style:normal'>Club Championship 2017 Event 9</h1>
 
 
 
+

--- a/2017ClubChampionshipJuniors.htm
+++ b/2017ClubChampionshipJuniors.htm
@@ -296,3 +296,4 @@ font-style:normal'>Club Championship 2017 Juniors</h1>
 
 
 
+

--- a/2017ClubChampionshipJuveniles.htm
+++ b/2017ClubChampionshipJuveniles.htm
@@ -480,3 +480,4 @@ font-style:normal'>Club Championship 2017 Juveniles</h1>
 
 
 
+

--- a/2017ClubChampionshipLeague1.htm
+++ b/2017ClubChampionshipLeague1.htm
@@ -309,7 +309,7 @@ font-style:normal'>Club Championship 2017 DC Research 1</h1>
   <td height=38 class=xl30229160 width=113 style='height:28.2pt;width:85pt'>Name</td>
   <td class=xl30129160 width=68 style='width:51pt'>Current rank</td>
   <td class=xl30129160 width=92 style='width:69pt'>Events Completed</td>
-  <td class=xl30329160 width=80 style='width:60pt'>FC points best 6</td>
+  <td class=xl30329160 width=80 style='width:60pt'>DC points best 6</td>
   <td class=xl29929160 width=46 style='border-top:none;width:35pt'>Hard 5</td>
   <td class=xl29929160 width=48 style='border-top:none;border-left:none;
   width:36pt'>Hard 8.5</td>
@@ -504,6 +504,7 @@ font-style:normal'>Club Championship 2017 DC Research 1</h1>
 </body>
 
 </html>
+
 
 
 

--- a/2017ClubChampionshipLeague2.htm
+++ b/2017ClubChampionshipLeague2.htm
@@ -309,7 +309,7 @@ font-style:normal'>Club Championship 2017 DC Research 2</h1>
   <td height=38 class=xl30229179 width=113 style='height:28.2pt;width:85pt'>Name</td>
   <td class=xl30129179 width=68 style='width:51pt'>Current rank</td>
   <td class=xl30129179 width=92 style='width:69pt'>Events Completed</td>
-  <td class=xl30329179 width=80 style='width:60pt'>FC points best 6</td>
+  <td class=xl30329179 width=80 style='width:60pt'>DC points best 6</td>
   <td class=xl29929179 width=46 style='border-top:none;width:35pt'>Hard 5</td>
   <td class=xl29929179 width=48 style='border-top:none;border-left:none;
   width:36pt'>Hard 8.5</td>
@@ -487,6 +487,7 @@ font-style:normal'>Club Championship 2017 DC Research 2</h1>
 </body>
 
 </html>
+
 
 
 

--- a/2017ClubChampionshipLeague3.htm
+++ b/2017ClubChampionshipLeague3.htm
@@ -309,7 +309,7 @@ font-style:normal'>Club Championship 2017 DC Research 3</h1>
   <td height=38 class=xl30229197 width=113 style='height:28.2pt;width:85pt'>Name</td>
   <td class=xl30129197 width=68 style='width:51pt'>Current rank</td>
   <td class=xl30129197 width=92 style='width:69pt'>Events Completed</td>
-  <td class=xl30329197 width=80 style='width:60pt'>FC points best 6</td>
+  <td class=xl30329197 width=80 style='width:60pt'>DC points best 6</td>
   <td class=xl29929197 width=46 style='border-top:none;width:35pt'>Hard 5</td>
   <td class=xl29929197 width=48 style='border-top:none;border-left:none;
   width:36pt'>Hard 8.5</td>
@@ -540,6 +540,7 @@ font-style:normal'>Club Championship 2017 DC Research 3</h1>
 </body>
 
 </html>
+
 
 
 

--- a/2017ClubChampionshipLeague4.htm
+++ b/2017ClubChampionshipLeague4.htm
@@ -310,7 +310,7 @@ font-style:normal'>Club Championship 2017 DC Research 4</h1>
   <td height=38 class=xl30229215 width=113 style='height:28.2pt;width:85pt'>Name</td>
   <td class=xl30129215 width=68 style='width:51pt'>Current rank</td>
   <td class=xl30129215 width=92 style='width:69pt'>Events Completed</td>
-  <td class=xl30329215 width=80 style='width:60pt'>FC points best 6</td>
+  <td class=xl30329215 width=80 style='width:60pt'>DC points best 6</td>
   <td class=xl29929215 width=46 style='border-top:none;width:35pt'>Hard 5</td>
   <td class=xl29929215 width=48 style='border-top:none;border-left:none;
   width:36pt'>Hard 8.5</td>
@@ -577,6 +577,7 @@ font-style:normal'>Club Championship 2017 DC Research 4</h1>
 </body>
 
 </html>
+
 
 
 

--- a/2017ClubChampionshipLeaguePrem.htm
+++ b/2017ClubChampionshipLeaguePrem.htm
@@ -309,7 +309,7 @@ font-style:normal'>Club Championship 2017 DC Research Prem</h1>
   <td height=38 class=xl30229141 width=113 style='height:28.2pt;width:85pt'>Name</td>
   <td class=xl30129141 width=68 style='width:51pt'>Current rank</td>
   <td class=xl30129141 width=92 style='width:69pt'>Events Completed</td>
-  <td class=xl30329141 width=80 style='width:60pt'>FC points best 6</td>
+  <td class=xl30329141 width=80 style='width:60pt'>DC points best 6</td>
   <td class=xl29929141 width=46 style='border-top:none;width:35pt'>Hard 5</td>
   <td class=xl29929141 width=48 style='border-top:none;border-left:none;
   width:36pt'>Hard 8.5</td>
@@ -486,6 +486,7 @@ font-style:normal'>Club Championship 2017 DC Research Prem</h1>
 </body>
 
 </html>
+
 
 
 

--- a/2017ClubChampionshipRoadBikeMen.htm
+++ b/2017ClubChampionshipRoadBikeMen.htm
@@ -960,3 +960,4 @@ font-style:normal'>Club Championship 2017 Road Bike Men</h1>
 
 
 
+

--- a/2017ClubChampionshipRoadBikeWomen.htm
+++ b/2017ClubChampionshipRoadBikeWomen.htm
@@ -483,3 +483,4 @@ font-style:normal'>Club Championship 2017 Road Bike Women</h1>
 
 
 
+

--- a/2017ClubChampionshipSeniors.htm
+++ b/2017ClubChampionshipSeniors.htm
@@ -1795,3 +1795,4 @@ font-style:normal'>Club Championship 2017 Seniors</h1>
 
 
 
+

--- a/2017ClubChampionshipVeterans.htm
+++ b/2017ClubChampionshipVeterans.htm
@@ -927,3 +927,4 @@ font-style:normal'>Club Championship 2017 Veterans</h1>
 
 
 
+

--- a/2017ClubChampionshipWomen.htm
+++ b/2017ClubChampionshipWomen.htm
@@ -544,3 +544,4 @@ font-style:normal'>Club Championship 2017 Women</h1>
 
 
 
+

--- a/2017Evening10SeriesEvent1.htm
+++ b/2017Evening10SeriesEvent1.htm
@@ -644,3 +644,4 @@ font-style:normal'>Evening 10 Series 2017 Event 1</h1>
 
 
 
+

--- a/2017Evening10SeriesEvent10.htm
+++ b/2017Evening10SeriesEvent10.htm
@@ -582,3 +582,4 @@ font-style:normal'>Evening 10 Series 2017 Event 10</h1>
 
 
 
+

--- a/2017Evening10SeriesEvent11.htm
+++ b/2017Evening10SeriesEvent11.htm
@@ -349,7 +349,7 @@ font-style:normal'>Evening 10 Series 2017 Event 11</h1>
  <tr height=20 style='height:15.0pt'>
   <td height=20 class=xl30323355 style='height:15.0pt;border-top:none'>Lawrence
   Cox</td>
-  <td class=xl30423355 style='border-top:none;border-left:none'>4</td>
+  <td class=xl30423355 style='border-top:none;border-left:none'>5</td>
   <td class=xl30423355 style='border-top:none;border-left:none'>&nbsp;</td>
   <td class=xl30523355 style='border-top:none;border-left:none'>00:23:44</td>
   <td class=xl30223355 style='border-top:none;border-left:none'>25.28</td>
@@ -553,6 +553,7 @@ font-style:normal'>Evening 10 Series 2017 Event 11</h1>
 </body>
 
 </html>
+
 
 
 

--- a/2017Evening10SeriesEvent12.htm
+++ b/2017Evening10SeriesEvent12.htm
@@ -270,3 +270,4 @@ font-style:normal'>Evening 10 Series 2017 Event 12</h1>
 
 
 
+

--- a/2017Evening10SeriesEvent13.htm
+++ b/2017Evening10SeriesEvent13.htm
@@ -269,3 +269,4 @@ font-style:normal'>Evening 10 Series 2017 Event 13</h1>
 
 
 
+

--- a/2017Evening10SeriesEvent14.htm
+++ b/2017Evening10SeriesEvent14.htm
@@ -278,3 +278,4 @@ font-style:normal'>Evening 10 Series 2017 Event 14</h1>
 
 
 
+

--- a/2017Evening10SeriesEvent15.htm
+++ b/2017Evening10SeriesEvent15.htm
@@ -270,3 +270,4 @@ font-style:normal'>Evening 10 Series 2017 Event 15</h1>
 
 
 
+

--- a/2017Evening10SeriesEvent16.htm
+++ b/2017Evening10SeriesEvent16.htm
@@ -269,3 +269,4 @@ font-style:normal'>Evening 10 Series 2017 Event 16</h1>
 
 
 
+

--- a/2017Evening10SeriesEvent2.htm
+++ b/2017Evening10SeriesEvent2.htm
@@ -695,3 +695,4 @@ font-style:normal'>Evening 10 Series 2017 Event 2</h1>
 
 
 
+

--- a/2017Evening10SeriesEvent3.htm
+++ b/2017Evening10SeriesEvent3.htm
@@ -715,3 +715,4 @@ font-style:normal'>Evening 10 Series 2017 Event 3</h1>
 
 
 
+

--- a/2017Evening10SeriesEvent4.htm
+++ b/2017Evening10SeriesEvent4.htm
@@ -530,3 +530,4 @@ font-style:normal'>Evening 10 Series 2017 Event 4</h1>
 
 
 
+

--- a/2017Evening10SeriesEvent5.htm
+++ b/2017Evening10SeriesEvent5.htm
@@ -523,3 +523,4 @@ font-style:normal'>Evening 10 Series 2017 Event 5</h1>
 
 
 
+

--- a/2017Evening10SeriesEvent6.htm
+++ b/2017Evening10SeriesEvent6.htm
@@ -563,3 +563,4 @@ font-style:normal'>Evening 10 Series 2017 Event 6</h1>
 
 
 
+

--- a/2017Evening10SeriesEvent7.htm
+++ b/2017Evening10SeriesEvent7.htm
@@ -725,3 +725,4 @@ font-style:normal'>Evening 10 Series 2017 Event 7</h1>
 
 
 
+

--- a/2017Evening10SeriesEvent8.htm
+++ b/2017Evening10SeriesEvent8.htm
@@ -578,3 +578,4 @@ font-style:normal'>Evening 10 Series 2017 Event 8</h1>
 
 
 
+

--- a/2017Evening10SeriesEvent9.htm
+++ b/2017Evening10SeriesEvent9.htm
@@ -435,3 +435,4 @@ font-style:normal'>Evening 10 Series 2017 Event 9</h1>
 
 
 
+

--- a/2017Evening10SeriesJuniors.htm
+++ b/2017Evening10SeriesJuniors.htm
@@ -326,3 +326,4 @@ font-style:normal'>Evening 10 Series 2017 Juniors</h1>
 
 
 
+

--- a/2017Evening10SeriesJuveniles.htm
+++ b/2017Evening10SeriesJuveniles.htm
@@ -551,3 +551,4 @@ font-style:normal'>Evening 10 Series 2017 Juveniles</h1>
 
 
 
+

--- a/2017Evening10SeriesRoadBikeMen.htm
+++ b/2017Evening10SeriesRoadBikeMen.htm
@@ -1138,3 +1138,4 @@ font-style:normal'>Evening 10 Series 2017 Road Bike Men</h1>
 
 
 
+

--- a/2017Evening10SeriesRoadBikeWomen.htm
+++ b/2017Evening10SeriesRoadBikeWomen.htm
@@ -424,3 +424,4 @@ font-style:normal'>Evening 10 Series 2017 Road Bike Women</h1>
 
 
 
+

--- a/2017Evening10SeriesSeniors.htm
+++ b/2017Evening10SeriesSeniors.htm
@@ -2765,3 +2765,4 @@ font-style:normal'>Evening 10 Series 2017 Seniors</h1>
 
 
 
+

--- a/2017Evening10SeriesVeterans.htm
+++ b/2017Evening10SeriesVeterans.htm
@@ -1264,3 +1264,4 @@ font-style:normal'>Evening 10 Series 2017 Veterans</h1>
 
 
 
+

--- a/2017Evening10SeriesWomen.htm
+++ b/2017Evening10SeriesWomen.htm
@@ -592,3 +592,4 @@ font-style:normal'>Evening 10 Series 2017 Women</h1>
 
 
 
+


### PR DESCRIPTION
Handle duplicate times
If we know a fraction of a second, enter that in column D and the results will show the full seconds still, but the ranking will take the fraction into account.

So Phil Rayner: 23:44.67; Lawrence Cox: 23:44.82 - Phil is the faster.

Changes made to both CC and Ev10 workbooks.

Also - League tables still had FC in a column header.  Changed to DC.  Thanks to Andrew Weatherby for spotting this error.